### PR TITLE
Clarify supported invoice statuses

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,7 +44,7 @@ class Invoice(db.Model):
     date = db.Column(db.Date, default=datetime.utcnow)
     due_date = db.Column(db.Date)
     notes = db.Column(db.Text)
-    status = db.Column(db.String(20), default="draft")  # draft/sent/paid
+    status = db.Column(db.String(20), default="draft")  # draft/sent
 
 class InvoiceItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)


### PR DESCRIPTION
## Summary
- Adjust the Invoice model comment to indicate only `draft` and `sent` statuses are supported.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc3dbefe0832d85ff3a6b651aa299