### PR TITLE
Split customer name and add country dropdown

### DIFF
--- a/templates/customer_form.html
+++ b/templates/customer_form.html
@@ -4,8 +4,12 @@
 <form method="post" class="bg-white rounded-2xl shadow-sm border p-6 max-w-2xl">
   <div class="grid md:grid-cols-2 gap-4">
     <div>
-      <label class="text-sm text-slate-600">Name</label>
-      <input required name="name" value="{{ customer.name if customer }}" class="mt-1 w-full px-3 py-2 rounded-lg border">
+      <label class="text-sm text-slate-600">First Name</label>
+      <input required name="first_name" value="{{ customer.first_name if customer }}" class="mt-1 w-full px-3 py-2 rounded-lg border">
+    </div>
+    <div>
+      <label class="text-sm text-slate-600">Last Name</label>
+      <input required name="last_name" value="{{ customer.last_name if customer }}" class="mt-1 w-full px-3 py-2 rounded-lg border">
     </div>
     <div>
       <label class="text-sm text-slate-600">Email</label>
@@ -30,6 +34,14 @@
     <div>
       <label class="text-sm text-slate-600">Postal Code</label>
       <input name="postal_code" value="{{ customer.postal_code if customer }}" class="mt-1 w-full px-3 py-2 rounded-lg border">
+    </div>
+    <div>
+      <label class="text-sm text-slate-600">Country</label>
+      <select name="country" class="mt-1 w-full px-3 py-2 rounded-lg border">
+        {% for c in countries %}
+        <option value="{{ c }}" {% if (customer and customer.country==c) or (not customer and loop.first) %}selected{% endif %}>{{ c }}</option>
+        {% endfor %}
+      </select>
     </div>
   </div>
   <div class="mt-6 flex gap-3">

--- a/templates/customers.html
+++ b/templates/customers.html
@@ -21,7 +21,7 @@
     <tbody>
       {% for c in customers %}
       <tr class="border-t">
-        <td class="p-3">{{ c.name }}</td>
+        <td class="p-3">{{ c.full_name }}</td>
         <td class="p-3">{{ c.email }}</td>
         <td class="p-3">{{ c.phone }}</td>
         <td class="p-3">

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <div class="divide-y">
       {% for inv in invoices %}
       <a href="{{ url_for('invoice_view', iid=inv.id) }}" class="flex items-center justify-between py-3 hover:bg-slate-50 rounded-lg px-2">
-        <div>#{{ inv.id }} • {{ inv.customer.name }}</div>
+        <div>#{{ inv.id }} • {{ inv.customer.full_name }}</div>
         <div class="text-slate-600">{{ inv.date.strftime('%Y-%m-%d') }}</div>
       </a>
       {% else %}
@@ -26,7 +26,7 @@
     <div class="divide-y">
       {% for c in customers %}
       <div class="flex items-center justify-between py-3">
-        <div>{{ c.name }}</div>
+        <div>{{ c.full_name }}</div>
         <div class="text-slate-600">{{ c.email }}</div>
       </div>
       {% else %}

--- a/templates/invoice_email.html
+++ b/templates/invoice_email.html
@@ -16,7 +16,7 @@
       <h2>Invoice #{{ inv.id }}</h2>
       <div class="muted">Date: {{ inv.date.strftime('%Y-%m-%d') if inv.date }}</div>
       <h3>Bill To</h3>
-      <div>{{ inv.customer.name }} — {{ inv.customer.email }}</div>
+      <div>{{ inv.customer.full_name }} — {{ inv.customer.email }}</div>
       <h3>Items</h3>
       <table>
         <thead><tr><th>Description</th><th>Qty</th><th>Unit</th><th>Total</th></tr></thead>

--- a/templates/invoice_new.html
+++ b/templates/invoice_new.html
@@ -8,7 +8,7 @@
       <select name="customer_id" required class="mt-1 w-full px-3 py-2 rounded-lg border">
         <option value="">Select...</option>
         {% for c in customers %}
-        <option value="{{ c.id }}">{{ c.name }} — {{ c.email }}</option>
+        <option value="{{ c.id }}">{{ c.full_name }} — {{ c.email }}</option>
         {% endfor %}
       </select>
     </div>

--- a/templates/invoice_view.html
+++ b/templates/invoice_view.html
@@ -17,11 +17,12 @@
   <div class="grid md:grid-cols-2 gap-6 mt-6">
     <div class="bg-slate-50 border rounded-xl p-4">
       <div class="font-semibold mb-1">Bill To</div>
-      <div>{{ inv.customer.name }}</div>
+      <div>{{ inv.customer.full_name }}</div>
       <div class="text-slate-600">{{ inv.customer.email }}</div>
       {% if inv.customer.phone %}<div class="text-slate-600">{{ inv.customer.phone }}</div>{% endif %}
       {% if inv.customer.address %}<div class="text-slate-600">{{ inv.customer.address }}</div>{% endif %}
       <div class="text-slate-600">{{ inv.customer.city }} {{ inv.customer.state }} {{ inv.customer.postal_code }}</div>
+      {% if inv.customer.country %}<div class="text-slate-600">{{ inv.customer.country }}</div>{% endif %}
     </div>
     <div class="bg-slate-50 border rounded-xl p-4">
       <div class="font-semibold mb-1">Summary</div>

--- a/templates/invoices.html
+++ b/templates/invoices.html
@@ -21,7 +21,7 @@
       {% for inv in invoices %}
       <tr class="border-t">
         <td class="p-3">#{{ inv.id }}</td>
-        <td class="p-3">{{ inv.customer.name }}</td>
+        <td class="p-3">{{ inv.customer.full_name }}</td>
         <td class="p-3">{{ inv.date.strftime('%Y-%m-%d') if inv.date }}</td>
         <td class="p-3">{{ inv.due_date.strftime('%Y-%m-%d') if inv.due_date }}</td>
         <td class="p-3">{{ inv.status }}</td>


### PR DESCRIPTION
## Summary
- Replace single customer name with separate first and last name fields and add a country column.
- Update customer routes and templates to support new fields and a default country dropdown.
- Show full customer name and country across invoices, listings, and dashboard.

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc53a8ab4832db0c30714ee1eaa00